### PR TITLE
ci: publish multi-arch bridge images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,16 @@ env:
 
 jobs:
   build-ui:
-    runs-on: ubuntu-latest
+    name: Build UI (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -27,7 +36,70 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set platform output
+        id: platform
+        run: echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.UI_IMAGE }}
+
+      - name: Build and push UI image by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ui-${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,scope=ui-${{ steps.platform.outputs.pair }},mode=max
+          outputs: type=image,name=${{ env.UI_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export UI digest
+        run: |
+          mkdir -p /tmp/digests-ui
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests-ui/${digest#sha256:}"
+
+      - name: Upload UI digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-ui-${{ steps.platform.outputs.pair }}
+          path: /tmp/digests-ui/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-ui:
+    name: Merge UI manifest
+    runs-on: ubuntu-latest
+    needs: build-ui
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download UI digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests-ui
+          pattern: digests-ui-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract UI metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -38,13 +110,17 @@ jobs:
             type=sha
             type=sha,prefix=${{ github.ref_name }}-sha-,enable=${{ github.ref_type == 'branch' }}
 
-      - name: Build and push UI image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Merge UI manifest
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          cd /tmp/digests-ui
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.UI_IMAGE }}@sha256:%s ' *)
 
       - name: Dispatch bridge UI image tag to qfc-testnet
         if: github.ref_type == 'branch'
@@ -62,7 +138,16 @@ jobs:
           echo "Dispatched qfc-testnet update for bridge: ${TAG}"
 
   build-relayer:
-    runs-on: ubuntu-latest
+    name: Build Relayer (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -77,7 +162,70 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set platform output
+        id: platform
+        run: echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.RELAYER_IMAGE }}
+
+      - name: Build and push relayer image by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./relayer
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=relayer-${{ steps.platform.outputs.pair }}
+          cache-to: type=gha,scope=relayer-${{ steps.platform.outputs.pair }},mode=max
+          outputs: type=image,name=${{ env.RELAYER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export relayer digest
+        run: |
+          mkdir -p /tmp/digests-relayer
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests-relayer/${digest#sha256:}"
+
+      - name: Upload relayer digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-relayer-${{ steps.platform.outputs.pair }}
+          path: /tmp/digests-relayer/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-relayer:
+    name: Merge relayer manifest
+    runs-on: ubuntu-latest
+    needs: build-relayer
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download relayer digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests-relayer
+          pattern: digests-relayer-*
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract relayer metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -88,13 +236,17 @@ jobs:
             type=sha
             type=sha,prefix=${{ github.ref_name }}-sha-,enable=${{ github.ref_type == 'branch' }}
 
-      - name: Build and push Relayer image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./relayer
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Merge relayer manifest
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          cd /tmp/digests-relayer
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.RELAYER_IMAGE }}@sha256:%s ' *)
 
       - name: Dispatch bridge relayer image tag to qfc-testnet
         if: github.ref_type == 'branch'


### PR DESCRIPTION
## Summary
- build qfc-bridge UI images for linux/amd64 and linux/arm64
- build qfc-bridge-relayer images for linux/amd64 and linux/arm64
- merge per-platform digests into manifest tags, including immutable staging-sha tags
- keep qfc-testnet dispatch flow so ARM64 app hosts can deploy rollback-friendly tags

## Why
The testnet app VPS runs on ARM64 Graviton. The previous single-arch amd64 bridge images pulled successfully but failed at runtime with exec format error.